### PR TITLE
Update and freeze pre-commit hooks to git hash versus tagged release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,9 @@ minimum_pre_commit_version: "2.6.0"
 repos:
   -
     repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    # To update the frozen revs, run:  pre-commit autoupdate --freeze
+    # see: https://pre-commit.com/#pre-commit-autoupdate for more details.
+    rev: 8fe62d14e0b4d7d845a7022c5c2c3ae41bdd3f26  # frozen: v4.1.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -21,7 +23,7 @@ repos:
 
   - # see https://github.com/antonbabenko/pre-commit-terraform
     repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.0
+    rev: c2d1a58a5e7e448a66f3f8bb561f58ee3c95a461  # frozen: v1.64.0
     hooks:
       # see https://github.com/antonbabenko/pre-commit-terraform#terraform_fmt
       - id: terraform_fmt


### PR DESCRIPTION
The goal of this PR is to resolve #8 by updating and freezing the pre-commit hook `rev` to git sha via: 

**--freeze: new in 1.21.0: Store "frozen" hashes in [rev](https://pre-commit.com/#repos-rev) instead of tag names**