### PR TITLE
Add GIT_WORKING_DIR dunder ref tflint/tfsec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,8 @@ repos:
       # see https://github.com/antonbabenko/pre-commit-terraform#terraform_tflint
       - id: terraform_tflint
         args:
-          - "--args=--config=.tflint.hcl"
+          - "--args=--config=__GIT_WORKING_DIR__/.tflint.hcl"
 
       - id: terraform_tfsec
         args:
-          - "--args=--custom-check-dir=.tfsec"
+          - "--args=--custom-check-dir=__GIT_WORKING_DIR__/.tfsec"


### PR DESCRIPTION
The goal of this PR is to resolve #7 by adding the dunder var: `__GIT_WORKING_DIR__` to local paths used in `pre-commit` hooks in order to appropriately handle the git working directory context.