### PR TITLE
Updated pre-commit-config version, to solve MacOS issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
     repo: https://github.com/aws-ia/pre-commit-configs
     # To update run:
     # pre-commit autoupdate --freeze
-    rev: 80ed3f0a164f282afaac0b6aec70e20f7e541932  # frozen: v1.5.0
+    rev: c7091ec774495a41986bd9c5ea59152655ec4f3a  # frozen: v1.6.2
     hooks:
       - id: aws-ia-meta-hook


### PR DESCRIPTION
The original version of pre-commit-config was in turn relying on an old version of  pre-commit-terraform, that suffered of a bug on MacOS systems: https://github.com/antonbabenko/pre-commit-terraform/issues/337