### PR TITLE
Updated tflint aws ruleset version

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,7 +3,7 @@
 
 plugin "aws" {
   enabled = true
-  version = "0.14.0"
+  version = "0.22.1"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 


### PR DESCRIPTION
Original tflint aws plugin version was raising errors with the current aws provider. 